### PR TITLE
MINOR Removed meta key from inspector key triggers, as its already bound...

### DIFF
--- a/src/jquery.entwine.inspector.js
+++ b/src/jquery.entwine.inspector.js
@@ -36,7 +36,7 @@ jQuery(function($){
 	});
 
 	$('body').bind('keypress', function(e){
-		if ((e.ctrlKey || e.metaKey) && e.which == 96) {
+		if (e.ctrlKey && e.which == 96) {
 			if (inspectorPanel.css('visibility') != 'visible') {
 				inspectorPanel.css({top: 0, visibility: 'visible'});
 				$('body').css({marginTop: 400});


### PR DESCRIPTION
... to switching between windows in OSX. I'm no Windows shortcut expert, but don't think that key combo is bound to anything by default (see http://en.wikipedia.org/wiki/Table_of_keyboard_shortcuts).
