### PR TITLE
fixed entwine for usage with jquery 1.12.x and 2.2.x

### DIFF
--- a/dist/jquery.concrete-dist.js
+++ b/dist/jquery.concrete-dist.js
@@ -754,10 +754,12 @@ Sizzle is good for finding elements for a selector, but not so good for telling 
 	 * Copyright (c) 2007 Jörn Zaefferer
 	 */
 	if ($.support.focusinBubbles === undefined)  {
-		if($.browser.msie === undefined)  {
-			$.support.focusinBubbles = false;
-		} else {
+		try {
 			$.support.focusinBubbles = !!($.browser.msie);
+		} catch(err) {
+			if($.browser.msie === undefined)  {
+				$.support.focusinBubbles = (/msie|trident/i).test(navigator.userAgent);
+			}
 		}
 	}
 

--- a/dist/jquery.concrete-dist.js
+++ b/dist/jquery.concrete-dist.js
@@ -754,13 +754,7 @@ Sizzle is good for finding elements for a selector, but not so good for telling 
 	 * Copyright (c) 2007 Jörn Zaefferer
 	 */
 	if ($.support.focusinBubbles === undefined)  {
-		try {
-			$.support.focusinBubbles = !!($.browser.msie);
-		} catch(err) {
-			if($.browser.msie === undefined)  {
-				$.support.focusinBubbles = (/msie|trident/i).test(navigator.userAgent);
-			}
-		}
+		$.support.focusinBubbles = !!($.browser) && !$.browser.msie;
 	}
 
 	if (!$.support.focusinBubbles && !$.event.special.focusin) {

--- a/dist/jquery.concrete-dist.js
+++ b/dist/jquery.concrete-dist.js
@@ -747,14 +747,18 @@ Sizzle is good for finding elements for a selector, but not so good for telling 
 
 /* src/jquery.focusinout.js */
 
-(function($){	
-	
+(function($){
+
 	/**
 	 * Add focusin and focusout support to bind and live for browers other than IE. Designed to be usable in a delegated fashion (like $.live)
 	 * Copyright (c) 2007 Jörn Zaefferer
 	 */
 	if ($.support.focusinBubbles === undefined)  {
-		$.support.focusinBubbles = !!($.browser.msie);
+		if($.browser.msie === undefined)  {
+			$.support.focusinBubbles = false;
+		} else {
+			$.support.focusinBubbles = !!($.browser.msie);
+		}
 	}
 
 	if (!$.support.focusinBubbles && !$.event.special.focusin) {
@@ -777,11 +781,11 @@ Sizzle is good for finding elements for a selector, but not so good for telling 
 			};
 		});
 	}
-		
+
 	(function(){
 		//IE has some trouble with focusout with select and keyboard navigation
 		var activeFocus = null;
-	
+
 		$(document)
 			.bind('focusin', function(e){
 				var target = e.realTarget || e.target;
@@ -797,8 +801,9 @@ Sizzle is good for finding elements for a selector, but not so good for telling 
 				activeFocus = null;
 			});
 	})();
-	
-})(jQuery);;
+
+})(jQuery);
+;
 
 
 /* src/jquery.entwine.js */

--- a/dist/jquery.entwine-dist.js
+++ b/dist/jquery.entwine-dist.js
@@ -754,10 +754,12 @@ Sizzle is good for finding elements for a selector, but not so good for telling 
 	 * Copyright (c) 2007 Jörn Zaefferer
 	 */
 	if ($.support.focusinBubbles === undefined)  {
-		if($.browser.msie === undefined)  {
-			$.support.focusinBubbles = false;
-		} else {
+		try {
 			$.support.focusinBubbles = !!($.browser.msie);
+		} catch(err) {
+			if($.browser.msie === undefined)  {
+				$.support.focusinBubbles = (/msie|trident/i).test(navigator.userAgent);
+			}
 		}
 	}
 

--- a/dist/jquery.entwine-dist.js
+++ b/dist/jquery.entwine-dist.js
@@ -754,13 +754,7 @@ Sizzle is good for finding elements for a selector, but not so good for telling 
 	 * Copyright (c) 2007 Jörn Zaefferer
 	 */
 	if ($.support.focusinBubbles === undefined)  {
-		try {
-			$.support.focusinBubbles = !!($.browser.msie);
-		} catch(err) {
-			if($.browser.msie === undefined)  {
-				$.support.focusinBubbles = (/msie|trident/i).test(navigator.userAgent);
-			}
-		}
+		$.support.focusinBubbles = !!($.browser) && !$.browser.msie;
 	}
 
 	if (!$.support.focusinBubbles && !$.event.special.focusin) {

--- a/dist/jquery.entwine-dist.js
+++ b/dist/jquery.entwine-dist.js
@@ -747,14 +747,18 @@ Sizzle is good for finding elements for a selector, but not so good for telling 
 
 /* src/jquery.focusinout.js */
 
-(function($){	
-	
+(function($){
+
 	/**
 	 * Add focusin and focusout support to bind and live for browers other than IE. Designed to be usable in a delegated fashion (like $.live)
 	 * Copyright (c) 2007 Jörn Zaefferer
 	 */
 	if ($.support.focusinBubbles === undefined)  {
-		$.support.focusinBubbles = !!($.browser.msie);
+		if($.browser.msie === undefined)  {
+			$.support.focusinBubbles = false;
+		} else {
+			$.support.focusinBubbles = !!($.browser.msie);
+		}
 	}
 
 	if (!$.support.focusinBubbles && !$.event.special.focusin) {
@@ -777,11 +781,11 @@ Sizzle is good for finding elements for a selector, but not so good for telling 
 			};
 		});
 	}
-		
+
 	(function(){
 		//IE has some trouble with focusout with select and keyboard navigation
 		var activeFocus = null;
-	
+
 		$(document)
 			.bind('focusin', function(e){
 				var target = e.realTarget || e.target;
@@ -797,8 +801,9 @@ Sizzle is good for finding elements for a selector, but not so good for telling 
 				activeFocus = null;
 			});
 	})();
-	
-})(jQuery);;
+
+})(jQuery);
+;
 
 
 /* src/jquery.entwine.js */

--- a/src/jquery.focusinout.js
+++ b/src/jquery.focusinout.js
@@ -5,7 +5,7 @@
 	 * Copyright (c) 2007 Jörn Zaefferer
 	 */
 	if ($.support.focusinBubbles === undefined)  {
-		$.support.focusinBubbles = !!($.browser.msie) && !$.browser.msie;
+		$.support.focusinBubbles = !!($.browser) && !$.browser.msie;
 	}
 
 	if (!$.support.focusinBubbles && !$.event.special.focusin) {

--- a/src/jquery.focusinout.js
+++ b/src/jquery.focusinout.js
@@ -8,9 +8,7 @@
 		try {
 			$.support.focusinBubbles = !!($.browser.msie);
 		} catch(err) {
-			if($.browser.msie === undefined)  {
-				$.support.focusinBubbles = (/msie|trident/i).test(navigator.userAgent);
-			}
+			$.support.focusinBubbles = (/msie|trident/i).test(navigator.userAgent);
 		}
 	}
 

--- a/src/jquery.focusinout.js
+++ b/src/jquery.focusinout.js
@@ -5,11 +5,7 @@
 	 * Copyright (c) 2007 Jörn Zaefferer
 	 */
 	if ($.support.focusinBubbles === undefined)  {
-		try {
-			$.support.focusinBubbles = !!($.browser.msie);
-		} catch(err) {
-			$.support.focusinBubbles = (/msie|trident/i).test(navigator.userAgent);
-		}
+		$.support.focusinBubbles = !!($.browser.msie) && !$.browser.msie;
 	}
 
 	if (!$.support.focusinBubbles && !$.event.special.focusin) {

--- a/src/jquery.focusinout.js
+++ b/src/jquery.focusinout.js
@@ -5,10 +5,12 @@
 	 * Copyright (c) 2007 Jörn Zaefferer
 	 */
 	if ($.support.focusinBubbles === undefined)  {
-		if($.browser.msie === undefined)  {
-			$.support.focusinBubbles = false;
-		} else {
+		try {
 			$.support.focusinBubbles = !!($.browser.msie);
+		} catch(err) {
+			if($.browser.msie === undefined)  {
+				$.support.focusinBubbles = (/msie|trident/i).test(navigator.userAgent);
+			}
 		}
 	}
 

--- a/src/jquery.focusinout.js
+++ b/src/jquery.focusinout.js
@@ -1,11 +1,15 @@
-(function($){	
-	
+(function($){
+
 	/**
 	 * Add focusin and focusout support to bind and live for browers other than IE. Designed to be usable in a delegated fashion (like $.live)
 	 * Copyright (c) 2007 Jörn Zaefferer
 	 */
 	if ($.support.focusinBubbles === undefined)  {
-		$.support.focusinBubbles = !!($.browser.msie);
+		if($.browser.msie === undefined)  {
+			$.support.focusinBubbles = false;
+		} else {
+			$.support.focusinBubbles = !!($.browser.msie);
+		}
 	}
 
 	if (!$.support.focusinBubbles && !$.event.special.focusin) {
@@ -28,11 +32,11 @@
 			};
 		});
 	}
-		
+
 	(function(){
 		//IE has some trouble with focusout with select and keyboard navigation
 		var activeFocus = null;
-	
+
 		$(document)
 			.bind('focusin', function(e){
 				var target = e.realTarget || e.target;
@@ -48,5 +52,5 @@
 				activeFocus = null;
 			});
 	})();
-	
+
 })(jQuery);


### PR DESCRIPTION
Hi Hamisch, I had some errors regarding your $.browser.msie fix on jquery 1.12.x and 2.2.x so I fixed it.

Can you please review and merge my pull request, to have that fix to be part of the next silverstripe security release?

kind regards